### PR TITLE
Fix @polyvar macro when package is `import`ed

### DIFF
--- a/src/mono.jl
+++ b/src/mono.jl
@@ -11,7 +11,7 @@ end
 
 function buildpolyvar(var)
     if isa(var, Symbol)
-        esc(:($var = PolyVar($"$var")))
+        :($(esc(var)) = PolyVar($"$var"))
     else
         isa(var, Expr) || error("Expected $var to be a variable name")
         Base.Meta.isexpr(var, :ref) || error("Expected $var to be of the form varname[idxset]")
@@ -20,7 +20,7 @@ function buildpolyvar(var)
         varname = var.args[1]
         prefix = string(var.args[1])
         idxset = var.args[2]
-        esc(:($varname = polyvecvar($prefix, $idxset)))
+        :($(esc(varname)) = polyvecvar($prefix, $idxset))
     end
 end
 

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -15,3 +15,14 @@ facts("Vector to Monomial Vector") do
     @fact MonomialVector([1]) --> MonomialVector(PolyVar[], [Int[]])
     @fact MonomialVector([x]) --> MonomialVector([x], [[1]])
 end
+module newmodule
+  using FactCheck
+  import MultivariatePolynomials
+  facts("Polyvar macro hygiene") do
+    # Verify that the @polyvar macro works when the package has been activated
+    # with `import` instead of `using`.
+    MultivariatePolynomials.@polyvar x y
+    @fact isa(x, MultivariatePolynomials.PolyVar) --> true
+    @fact isa(y, MultivariatePolynomials.PolyVar) --> true
+  end
+end

--- a/test/mono.jl
+++ b/test/mono.jl
@@ -16,13 +16,13 @@ facts("Vector to Monomial Vector") do
     @fact MonomialVector([x]) --> MonomialVector([x], [[1]])
 end
 module newmodule
-  using FactCheck
-  import MultivariatePolynomials
-  facts("Polyvar macro hygiene") do
-    # Verify that the @polyvar macro works when the package has been activated
-    # with `import` instead of `using`.
-    MultivariatePolynomials.@polyvar x y
-    @fact isa(x, MultivariatePolynomials.PolyVar) --> true
-    @fact isa(y, MultivariatePolynomials.PolyVar) --> true
-  end
+    using FactCheck
+    import MultivariatePolynomials
+    facts("Polyvar macro hygiene") do
+        # Verify that the @polyvar macro works when the package has been activated
+        # with `import` instead of `using`.
+        MultivariatePolynomials.@polyvar x y
+        @fact isa(x, MultivariatePolynomials.PolyVar) --> true
+        @fact isa(y, MultivariatePolynomials.PolyVar) --> true
+    end
 end


### PR DESCRIPTION
`@polyvar x` only works when the package has been included with `using`, rather than `import`, because it tries to use the `PolyVar()` defined in the context in which the macro is *called*, rather than the context in which it was *defined*. This change should fix that. 