### PR TITLE
disable osx on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.5
   - nightly


### PR DESCRIPTION
Running OSX builds on Travis is quite slow, since they have very few OSX machines available. Since this package has no non-Julia code, it's very unlikely that an OSX build will tell us something that the Linux and Windows builds don't already. 