### PR TITLE
Add hash functions

### DIFF
--- a/src/poly.jl
+++ b/src/poly.jl
@@ -17,6 +17,9 @@ type Term{C, T} <: TermContainer{C, T}
     α::T
     x::Monomial{C}
 end
+
+Base.hash(t::Term, u::UInt64) = t.α == 1 ? hash(t.x, u) : hash(t.x, hash(t.α, u))
+
 iscomm{C, T}(::Type{Term{C, T}}) = C
 Term(t::Term) = t
 (::Type{Term{C}}){C}(x::Monomial{C}) = Term{C, Int}(x)
@@ -90,6 +93,16 @@ type Polynomial{C, T} <: TermContainer{C, T}
     end
 end
 iscomm{C, T}(::Type{Polynomial{C, T}}) = C
+
+function Base.hash(p::Polynomial, u::UInt64)
+    if length(p.a) == 0
+        hash(0, u)
+    elseif length(p.a) == 1
+        hash(Term(p.a[1], Monomial(p.x[1])))
+    else
+        hash(p.a, hash(p.x, hash(u)))
+    end
+end
 
 Base.copy{C, T}(p::Polynomial{C, T}) = Polynomial{C, T}(copy(p.a), copy(p.x))
 zero{C, T}(::Type{Polynomial{C, T}}) = Polynomial(T[], MonomialVector{C}())

--- a/test/hash.jl
+++ b/test/hash.jl
@@ -1,0 +1,14 @@
+@testset "Hashing" begin
+    @polyvar x y z
+    @test hash(x) != hash(y)
+    @test hash(1x) == hash(1.0x)
+    @test hash(1x+3y) == hash(1.0x+3.0y)
+    @test hash(one(x)) == hash(x^0)
+    @test hash(x*y) == hash(Polynomial(x*y))
+    @test hash(Term(1.0, Monomial(x))) == hash(x)
+    @test hash(x-x) == hash(zero(x))
+    @test hash(MonomialVector([z, y, x], [[3, 0, 0], [1,0,1]])) == hash(MonomialVector([z, x], [[3, 0], [1, 1]]))
+    @test hash(Monomial([z, y, x], [3, 0, 0])) == hash(Monomial([z, x], [3, 0]))
+    @test hash(1) == hash(one(x))
+    @test hash(0.0) == hash(x-x)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ include("ncalg.jl")
 include("diff.jl")
 include("subs.jl")
 include("algebraicset.jl")
+include("hash.jl")
 
 include("show.jl")
 


### PR DESCRIPTION
Here are some hash functions for the PolyVar, Monomial, Term, MonomialVector, and Polynomial types. 

These are necessary because when two Julia objects are `isequal`, their hashes should be the same. Like `hash(1) == hash(1.0)` we now have `hash(x+y) == hash(1.0x + 1.0y)` etc.

For this I have added a `canonical` function to transform monomials and monomial vectors into a canonical form by removing unused variables. 

I've also added some tests.
