### PR TITLE
Workaround for #22

### DIFF
--- a/src/comp.jl
+++ b/src/comp.jl
@@ -125,8 +125,8 @@ function (==){C}(s::Term{C}, t::Term{C})
     (s.α == t.α) && (iszero(s.α) || s.x == t.x)
 end
 function (==){C}(t::Term{C}, p::Polynomial{C})
-    if iszero(t.α)
-        isempty(p.a)
+    if isempty(p.a)
+        iszero(t.α)
     else
         length(p.a) == 1 && p.a[1] == t.α && p.x[1] == t.x
     end

--- a/test/comp.jl
+++ b/test/comp.jl
@@ -63,3 +63,19 @@ end
         @test !isapprox(2.001,  (2x) / x, rtol=1e-4)
     end
 end
+@testset "Equality between a Polynomial and a type not defining zero #22" begin
+    @polyvar x
+    # Polynomial of multiple terms
+    p = x + x^2
+    @test p != nothing
+    @test p != Dict{Int,Int}()
+    # Polynomial of one term
+    p = x + x^2 - x
+    @test p != nothing
+    @test p != Dict{Int,Int}()
+    # Polynomial of no term
+    # Waiting Julia v0.6 with Base.iszero to fix this
+    #p = x - x
+    #@test p != nothing
+    #@test p != Dict{Int,Int}()
+end


### PR DESCRIPTION
I have pushed a workaround in #23 It calls `iszero` only if the polynomial is zero.