### PR TITLE
Eliminate build failure on julia 0.7

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -2,8 +2,9 @@ function show(io::IO, v::AbstractVariable)
     print(io, name(v))
 end
 
-
-_isone(x::T) where T = x == one(T)
+if VERSION < v"0.7.0-DEV.1319"
+    isone(x::T) where T = x == one(T)
+end
 
 function show(io::IO, m::AbstractMonomial)
     if isconstant(m)
@@ -12,7 +13,7 @@ function show(io::IO, m::AbstractMonomial)
         for (var, exp) in zip(variables(m), exponents(m))
             if !iszero(exp)
                 print(io, var)
-                if !_isone(exp)
+                if !isone(exp)
                     print(io, "^", exp)
                 end
             end
@@ -24,7 +25,7 @@ function Base.show(io::IO, t::AbstractTerm)
     if isconstant(t)
         print(io, coefficient(t))
     else
-        if !_isone(coefficient(t))
+        if !isone(coefficient(t))
             print(io, coefficient(t))
         end
         if !iszero(t)

--- a/src/show.jl
+++ b/src/show.jl
@@ -2,7 +2,9 @@ function show(io::IO, v::AbstractVariable)
     print(io, name(v))
 end
 
-isone(x::T) where T = x == one(T)
+
+_isone(x::T) where T = x == one(T)
+
 function show(io::IO, m::AbstractMonomial)
     if isconstant(m)
         print(io, "1")
@@ -10,7 +12,7 @@ function show(io::IO, m::AbstractMonomial)
         for (var, exp) in zip(variables(m), exponents(m))
             if !iszero(exp)
                 print(io, var)
-                if !isone(exp)
+                if !_isone(exp)
                     print(io, "^", exp)
                 end
             end
@@ -22,7 +24,7 @@ function Base.show(io::IO, t::AbstractTerm)
     if isconstant(t)
         print(io, coefficient(t))
     else
-        if !isone(coefficient(t))
+        if !_isone(coefficient(t))
             print(io, coefficient(t))
         end
         if !iszero(t)


### PR DESCRIPTION
[This PR](https://github.com/JuliaLang/julia/pull/19635) introduced new Base functions and one of them was `Base.isone`.
With this change one can use the package on 0.7. Note that the tests still fail, but that seems to be a problem with DynamicPolynomials.